### PR TITLE
Fix potential error with using mime_content_type() with base64 encoded string

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,7 +41,7 @@
 	For more information, also see:
 	https://github.com/PHPCompatibility/PHPCompatibility
 	-->
-	<config name="testVersion" value="5.5-"/>
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibilityWP"/>
 
 	<!--
@@ -53,7 +53,7 @@
 	the wiki:
 	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="4.8"/>
+	<config name="minimum_supported_wp_version" value="5.6"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>


### PR DESCRIPTION
Ik heb besloten om niet te gaan voor de door @mvdhoek1 voorgestelde oplossing om te werken met URL's in plaats van base64_encode bestanden. De reden daarvoor is dat je niet zeker weet of elke toekomstige toepassing de mogelijkheid heeft om de afbeeldingen middels een URL aan te bieden.

Fixes #2 