### PR TITLE
Feature/4

### DIFF
--- a/src/admin/class-event-dates.php
+++ b/src/admin/class-event-dates.php
@@ -760,7 +760,7 @@ class Event_Dates {
 			}
 			$test = array( 'repeat_yearly' => $repeat_yearly ? $repeat_yearly : false );
             // @phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Intentional loose array matching.
-			if ( $test === $pattern ) {
+			if ( $test === $pattern && isset( $meta['event_date_start'] ) ) {
 				$dates[]      = $meta['event_date_start'];
 				$timestamps[] = strtotime( $meta['event_date_start'] );
 			}

--- a/src/rest_api/class-openagenda-controller.php
+++ b/src/rest_api/class-openagenda-controller.php
@@ -1329,7 +1329,7 @@ class Openagenda_Controller extends \WP_REST_Posts_Controller {
 		$item_data['next_date'] = $event_dates_class->get_next_date( $item->ID );
 
 		// add media files to the item data with some extra information from the attachment.
-		$media_files = get_post_meta( $item->ID, '_event_media_files', true );
+		$media_files = get_post_meta( $item->ID, 'event_media_files', true );
 		if ( ! empty( $media_files ) ) {
 			foreach ( $media_files as $id => $media_file ) {
 				$media_files[ $id ] = array(
@@ -1341,7 +1341,7 @@ class Openagenda_Controller extends \WP_REST_Posts_Controller {
 		}
 
 		// add images to the item data with some extra information from the attachment.
-		$images = get_post_meta( $item->ID, '_event_images', true );
+		$images = get_post_meta( $item->ID, 'event_images', true );
 		if ( ! empty( $images ) ) {
 			foreach ( $images as $id => $image ) {
 				$images[ $id ] = $this->create_image_output( $id, $image );
@@ -1361,7 +1361,7 @@ class Openagenda_Controller extends \WP_REST_Posts_Controller {
 		}
 
 		// Check if this event has a location linked and add it to the item data.
-		$location_id = get_post_meta( $item->ID, '_event_location', true );
+		$location_id = get_post_meta( $item->ID, 'event_location', true );
 		if ( $location_id ) {
 			$location              = get_post( $location_id );
 			$item_data['location'] = $this->prepare_location_for_response( $location, $request, false );

--- a/src/rest_api/class-openagenda-controller.php
+++ b/src/rest_api/class-openagenda-controller.php
@@ -895,9 +895,13 @@ class Openagenda_Controller extends \WP_REST_Posts_Controller {
 		$upload_dir  = wp_upload_dir();
 		$upload_path = str_replace( '/', DIRECTORY_SEPARATOR, $upload_dir['path'] ) . DIRECTORY_SEPARATOR;
 
-		$file_array = explode( ',', $base64_file );
-		$file       = $file_array[1];
-		$file       = str_replace( ' ', '+', $file );
+		if ( 'data:' === substr( $base64_file, 0, 5 ) ) {
+			$file_array = explode( ',', $base64_file );
+			$file       = $file_array[1];
+		} else {
+			$file = $base64_file;
+		}
+		$file = str_replace( ' ', '+', $file );
 
         // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$decoded   = base64_decode( $file );


### PR DESCRIPTION
Allow 'plain' base64 string, without `data:<mime-type>;base64,` prefix
+ small bugfixes

Fixes #4 