### PR TITLE
#16 fix for saving and showing the right fields for either specific dates type or complex dates type

### DIFF
--- a/src/admin/class-cmb2.php
+++ b/src/admin/class-cmb2.php
@@ -491,7 +491,7 @@ class Cmb2 {
 					'specific' => __( 'A specific date or date-range', 'openagenda-base' ),
 					'complex'  => __( 'A configurable repeating pattern', 'openagenda-base' ),
 				),
-				'default'      => 'complex',
+				'default'      => 'specific',
 				'show_in_rest' => true,
 			)
 		);

--- a/src/admin/class-event-dates.php
+++ b/src/admin/class-event-dates.php
@@ -116,6 +116,14 @@ class Event_Dates {
 			return;
 		}
 
+		// Check the dates types value and make sure only the fields of the selected group is saved.
+		$dates_type = get_post_meta( $post_id, 'event_dates_type', true );
+		if ( 'complex' === $dates_type ) {
+			delete_post_meta( $post_id, 'event_dates_group_specific' );
+		} elseif ( 'specific' === $dates_type ) {
+			delete_post_meta( $post_id, 'event_dates_group_complex' );
+		}
+
 		$openagenda_event_date_list = $this->create_date_list( $post_id, 'Y-m-d' );
 		delete_post_meta( $post_id, '_openagenda_event_date_list' );
 		foreach ( $openagenda_event_date_list as $openagenda_event_date ) {
@@ -127,8 +135,8 @@ class Event_Dates {
 		foreach ( $openagenda_event_date_time_list as $openagenda_event_date_time ) {
 			add_post_meta( $post_id, '_openagenda_event_date_time_list', $openagenda_event_date_time );
 		}
-		// UPDATE POST_EXPIRATION DATA.
 
+		// UPDATE POST_EXPIRATION DATA.
 		// By nature of a loop, the last element is the very last date.
 		$event_date = $openagenda_event_date_list ? max( $openagenda_event_date_list ) : null;
 		if ( $event_date ) {

--- a/src/admin/js/cmb2-conditional-logic.js
+++ b/src/admin/js/cmb2-conditional-logic.js
@@ -14,6 +14,26 @@ jQuery( document ).ready( function( $ ) {
   });
 
   /**
+   * Show or hide specific or complex group based on the value of dates types.
+   */
+  var $specific = $('.cmb2-id-event-dates-group-specific');
+  var $complex = $('.cmb2-id-event-dates-group-complex');
+  $specific.hide();
+  $complex.hide();
+
+  $('input[name="event_dates_type"]').on('change', function() {
+    var value = $(this).val();
+
+    if (value === 'specific') {
+      $specific.show();
+      $complex.hide();
+    } else {
+      $specific.hide();
+      $complex.show();
+    }
+  });
+
+  /**
    * Set up the functionality for CMB2 conditionals.
    */
   function CMB2ConditionalsInit( changeContext, conditionContext ) {

--- a/src/rest_api/class-openagenda-controller.php
+++ b/src/rest_api/class-openagenda-controller.php
@@ -488,7 +488,7 @@ class Openagenda_Controller extends \WP_REST_Posts_Controller {
 		$args = array();
 
 		$registered = parent::get_collection_params();
-		$prefix = 'location_';
+		$prefix     = 'location_';
 
 		/*
 		 * This array defines mappings between public API query parameters whose
@@ -1438,14 +1438,22 @@ class Openagenda_Controller extends \WP_REST_Posts_Controller {
 		// Add date type to the item data.
 		$item_data['dates_type'] = get_post_meta( $item->ID, 'event_dates_type', true );
 
-		// Sort event dates by date ASC.
-		$event_dates_class = new Event_Dates();
-		$event_dates       = $event_dates_class->get_date_list( $item->ID );
-		sort( $event_dates );
-		$item_data['dates'] = $event_dates;
+		// Check if fields corresponding to dates_type are set.
+		$event_dates_row = get_post_meta( $item->ID, 'event_dates_group_' . $item_data['dates_type'], true );
+		if ( empty( $event_dates_row ) || empty( $event_dates_row[0][ 'event_dates_' . $item_data['dates_type'] . '_start_date' ] ) ) {
+			// If not, set dates and next_date to null.
+			$item_data['dates']     = null;
+			$item_data['next_date'] = null;
+		} else {
+			// Sort event dates by date ASC.
+			$event_dates_class = new Event_Dates();
+			$event_dates       = $event_dates_class->get_date_list( $item->ID );
+			sort( $event_dates );
+			$item_data['dates'] = $event_dates;
 
-		// Get first date in the near future to sort events by date ASC.
-		$item_data['next_date'] = $event_dates_class->get_next_date( $item->ID );
+			// Get first date in the near future to sort events by date ASC.
+			$item_data['next_date'] = $event_dates_class->get_next_date( $item->ID );
+		}
 
 		// add media files to the item data with some extra information from the attachment.
 		$media_files = get_post_meta( $item->ID, 'event_media_files', true );


### PR DESCRIPTION
This fix is a 3-way fix:
1) In entering an event in the CMS, only show the specific group fields if in the field dates_types the selected value is specific. And only show the complex group fields if complex is selected.
2) When saving an event, the post_meta values of the NOT-selected dates_types group fields are deleted, where CMB2 automatically saves them.
3) When retrieving an event via the REST API, the dates array and the next_date value is empty when the dates_types is complex but no rows are added in the group, and the same for the specific group.